### PR TITLE
run dotnet restore and wait until process exit

### DIFF
--- a/test/FsAutoComplete.IntegrationTests/DotNetCore/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCore/Runner.fsx
@@ -6,7 +6,8 @@ open System
 Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
 File.Delete "output.json"
 
-Diagnostics.Process.Start("dotnet", "restore sample1/c1")
+runProcess __SOURCE_DIRECTORY__ "dotnet" "restore sample1/c1"
+|> ignore
 
 let p = new FsAutoCompleteWrapper()
 

--- a/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
+++ b/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
@@ -118,3 +118,21 @@ let writeNormalizedOutput (fn: string) (s: string) =
       for line in lines do
         f.Write(line)
         f.Write('\n')
+
+let runProcess (workingDir: string) (exePath: string) (args: string) =
+    let psi = System.Diagnostics.ProcessStartInfo()
+    psi.FileName <- exePath
+    psi.WorkingDirectory <- workingDir 
+    psi.RedirectStandardOutput <- false
+    psi.RedirectStandardError <- false
+    psi.Arguments <- args
+    psi.CreateNoWindow <- true
+    psi.UseShellExecute <- false
+
+    use p = new System.Diagnostics.Process()
+    p.StartInfo <- psi
+    p.Start() |> ignore
+    p.WaitForExit()
+      
+    let exitCode = p.ExitCode
+    exitCode


### PR DESCRIPTION
i added an helper method to run commands and wait (and not shown the shell window)

the exit code is ignored atm, i didnt find how to assert for zero, but is not that important now.

